### PR TITLE
Remove option mutations. AWS validate lifecycle provided stage & region.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,6 @@ const fs = require('fs-promise');
 class ServerlessPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
-    this.options = options;
 
     this.commands = {
       diff: {
@@ -39,23 +38,19 @@ class ServerlessPlugin {
       'diff:diff': this.diff.bind(this),
     };
 
-    this.options.stage = this.options.stage
-      || (this.serverless.service.defaults && this.serverless.service.defaults.stage)
-      || 'dev';
-    this.options.region = this.options.region
-      || (this.serverless.service.defaults && this.serverless.service.defaults.region)
-      || 'us-east-1';
-    this.options.diffTool = this.options.diffTool;
-    this.options.localTemplate = this.options.localTemplate
-      || '.serverless/cloudformation-template-update-stack.json';
-    this.options.orgTemplate = this.options.localTemplate.replace('.json', '.org.json');
-
-    AWS.config.update({ region: this.options.region });
-
-    this.cloudFormation = new AWS.CloudFormation();
+    let localTemplate = options.localTemplate || '.serverless/cloudformation-template-update-stack.json';
+    let orgTemplate = localTemplate.replace('.json', '.org.json');
+    this.options = {
+      diffTool: options.diffTool,
+      localTemplate,
+      orgTemplate,
+    };
   }
 
   downloadTemplate() {
+    this.serverless.pluginManager.spawn('aws:common:validate');
+    AWS.config.update({ region: this.serverless.getProvider('aws').getRegion() });
+    let cloudFormation = new AWS.CloudFormation();
     let stackName;
 
     const orgTemplate = this.options.orgTemplate;
@@ -65,7 +60,8 @@ class ServerlessPlugin {
         && this.serverless.service.provider.stackName !== '') {
       stackName = this.serverless.service.provider.stackName;
     } else {
-      stackName = `${this.serverless.service.service}-${this.options.stage}`;
+      let stage = this.serverless.getProvider('aws').getStage();
+      stackName = `${this.serverless.service.service}-${stage}`;
     }
 
     const params = {
@@ -75,7 +71,7 @@ class ServerlessPlugin {
 
     this.serverless.cli.log('Downloading currently deployed template');
 
-    return this.cloudFormation.getTemplate(params).promise()
+    return cloudFormation.getTemplate(params).promise()
       .then((data) => {
         let templateBody = JSON.parse(data.TemplateBody);
         templateBody = JSON.stringify(templateBody, null, 2);


### PR DESCRIPTION
Before this patch, options.region would result in ‘us-east-1’ whenever the `-s` or `--stage` was not provided to the serverless command, confusing other plugins that work with the region specified in `serverless.yml`

Now aws:common:validate is run first to calculate the variable substituted values required.