### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ class ServerlessPlugin {
               + '(e.g. "--diffTool \'ksdiff\'")',
             required: false,
             shortcut: 'dt',
+            type: 'string',
           },
           localTemplate: {
             usage:
@@ -29,6 +30,7 @@ class ServerlessPlugin {
               + 'cloudformation-template-update-stack.json\'")',
             required: false,
             shortcut: 'lt',
+            type: 'string',
           },
         },
       },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessPlugin for "diffTool", "localTemplate"
```